### PR TITLE
Upgrade Java 17 → 21

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup Java JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: 21
         distribution: zulu
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Setup git user

--- a/jitci-init.sh
+++ b/jitci-init.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 . ~/.sdkman/bin/sdkman-init.sh
-sdk install java 17.0.11-oracle
-sdk use java 17.0.11-oracle
+sdk install java 21.0.8-oracle
+sdk use java 21.0.8-oracle
 export JAVA_HOME=~/.sdkman/candidates/java/current
 export M3_VERSION=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/apache/maven/releases/latest | sed 's,https://github.com/apache/maven/releases/tag/maven-,,g')
 mvn wrapper:wrapper -Dmaven=${M3_VERSION} --no-transfer-progress

--- a/org.sf.feeling.decompiler.assembly/pom.xml
+++ b/org.sf.feeling.decompiler.assembly/pom.xml
@@ -12,8 +12,8 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>

--- a/org.sf.feeling.decompiler.cfr/pom.xml
+++ b/org.sf.feeling.decompiler.cfr/pom.xml
@@ -12,8 +12,8 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>

--- a/org.sf.feeling.decompiler.jd/pom.xml
+++ b/org.sf.feeling.decompiler.jd/pom.xml
@@ -14,8 +14,8 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>

--- a/org.sf.feeling.decompiler.procyon/pom.xml
+++ b/org.sf.feeling.decompiler.procyon/pom.xml
@@ -12,8 +12,8 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>

--- a/org.sf.feeling.decompiler.vineflower/pom.xml
+++ b/org.sf.feeling.decompiler.vineflower/pom.xml
@@ -12,8 +12,8 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>

--- a/org.sf.feeling.decompiler/pom.xml
+++ b/org.sf.feeling.decompiler/pom.xml
@@ -12,8 +12,8 @@
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<fernflower.version>252.25557.131</fernflower.version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<tycho.version>4.0.7</tycho.version>
 	</properties>
 


### PR DESCRIPTION
- Met à jour les références Java **17 → 21** dans les fichiers *.xml*, *.yml*/*.yaml* et *.sh* (y compris **.github/workflows/**).
- Résout dynamiquement la dernière **Java 21** pour **Temurin** et **Oracle** dans les commandes `sdk install/use java`.
- Versions détectées — Temurin : `21.0.8-tem` ; Oracle : `21.0.8-oracle`.