### PR TITLE
Upgrade Java 17 → 21

### DIFF
--- a/.github/workflows/update-jdk.yml
+++ b/.github/workflows/update-jdk.yml
@@ -136,12 +136,12 @@ jobs:
               -e 's#(<executionEnvironment>\s*)JavaSE-17(\s*</executionEnvironment>)#\1JavaSE-21\2#g' \
               "$f" || true
 
-            # Filtres LDAP OSGi: (&(osgi.ee=JavaSE)(version=17)) -> 21
+            # Filtres LDAP OSGi: (&(osgi.ee=JavaSE)(version=21)) -> 21
             sed -E -i \
               -e 's#(\(version=)17(\))#\121\2#g' \
               "$f" || true
 
-            # Plateforme P2 : a.jre.javase 17.0.0 -> 21.0.0
+            # Plateforme P2 : a.jre.javase 21.0.0 -> 21.0.0
             sed -E -i \
               -e 's#(a\.jre\.javase[[:space:]]+)17\.0\.0\b#\121.0.0#g' \
               -e 's#(id="a\.jre\.javase"[[:space:]]+version=")17\.0\.0(")#\121.0.0\2#g' \

--- a/candidates.env
+++ b/candidates.env
@@ -1,0 +1,2 @@
+JAVA21_TEM=21.0.8-tem
+JAVA21_ORACLE=21.0.8-oracle

--- a/org.sf.feeling.decompiler.cfr/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler.cfr/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.navigator,
  org.eclipse.ui.ide;resolution:=optional,
  org.eclipse.core.filesystem
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ECD Project Team
 Export-Package: org.sf.feeling.decompiler.cfr.actions,

--- a/org.sf.feeling.decompiler.jd/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler.jd/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.navigator,
  org.eclipse.ui.ide;resolution:=optional,
  org.eclipse.core.filesystem
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ECD Project Team
 Export-Package: org.sf.feeling.decompiler.jd.actions,

--- a/org.sf.feeling.decompiler.procyon/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler.procyon/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.navigator,
  org.eclipse.ui.ide;resolution:=optional,
  org.eclipse.core.filesystem
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ECD Project Team
 Export-Package: org.sf.feeling.decompiler.procyon.actions,

--- a/org.sf.feeling.decompiler.source.attach.tests/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler.source.attach.tests/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt.junit.core,
  org.eclipse.jdt.junit.runtime,
  org.sf.feeling.decompiler.source.attach
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ECD Project Team
 Bundle-ClassPath: target/lib/commons-io.jar,

--- a/org.sf.feeling.decompiler.source.attach/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler.source.attach/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jgit;resolution:=optional,
  com.jcraft.jsch;resolution:=optional,
  org.eclipse.m2e.jdt;resolution:=optional
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ECD Project Team
 Bundle-ClassPath: target/lib/commons-io.jar,

--- a/org.sf.feeling.decompiler.vineflower/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler.vineflower/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.navigator,
  org.eclipse.ui.ide;resolution:=optional,
  org.eclipse.core.filesystem
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ECD Project Team
 Export-Package: org.sf.feeling.decompiler.vineflower.actions,

--- a/org.sf.feeling.decompiler/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-ClassPath: target/lib/fernflower.jar,
  .
 Bundle-Name: Enhanced Class Decompiler
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.jface,

--- a/summary.txt
+++ b/summary.txt
@@ -1,0 +1,1 @@
+Latest 21 candidates → tem=21.0.8-tem,oracle=21.0.8-oracle


### PR DESCRIPTION
- Met à jour les références Java **17 → 21** dans les fichiers *.xml*, *.yml*/*.yaml*, *.properties*, *.sh* et artefacts **OSGi/Tycho** (MANIFEST.MF, *.target, *.tpd, *.product, *.bnd, feature.xml, category.xml).
- N’altère pas le runtime: **aucun JDK n’est installé**. SDKMAN est utilisé uniquement pour **résoudre les dernières versions 21**.
- Remplace intelligemment `sdk install/use java 17…-<vendor>` par la **dernière 21** correspondante (Temurin/Oracle).
- Candidats détectés via SDKMAN: Latest 21 candidates → tem=21.0.8-tem,oracle=21.0.8-oracle