### PR TITLE
Upgrade Java 17 → 21

### DIFF
--- a/org.sf.feeling.decompiler.cfr/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler.cfr/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.navigator,
  org.eclipse.ui.ide;resolution:=optional,
  org.eclipse.core.filesystem
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ECD Project Team
 Export-Package: org.sf.feeling.decompiler.cfr.actions,

--- a/org.sf.feeling.decompiler.jd/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler.jd/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.navigator,
  org.eclipse.ui.ide;resolution:=optional,
  org.eclipse.core.filesystem
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ECD Project Team
 Export-Package: org.sf.feeling.decompiler.jd.actions,

--- a/org.sf.feeling.decompiler.procyon/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler.procyon/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.navigator,
  org.eclipse.ui.ide;resolution:=optional,
  org.eclipse.core.filesystem
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ECD Project Team
 Export-Package: org.sf.feeling.decompiler.procyon.actions,

--- a/org.sf.feeling.decompiler.source.attach.tests/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler.source.attach.tests/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt.junit.core,
  org.eclipse.jdt.junit.runtime,
  org.sf.feeling.decompiler.source.attach
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ECD Project Team
 Bundle-ClassPath: target/lib/commons-io.jar,

--- a/org.sf.feeling.decompiler.source.attach/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler.source.attach/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jgit;resolution:=optional,
  com.jcraft.jsch;resolution:=optional,
  org.eclipse.m2e.jdt;resolution:=optional
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ECD Project Team
 Bundle-ClassPath: target/lib/commons-io.jar,

--- a/org.sf.feeling.decompiler.vineflower/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler.vineflower/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.navigator,
  org.eclipse.ui.ide;resolution:=optional,
  org.eclipse.core.filesystem
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: ECD Project Team
 Export-Package: org.sf.feeling.decompiler.vineflower.actions,

--- a/org.sf.feeling.decompiler/META-INF/MANIFEST.MF
+++ b/org.sf.feeling.decompiler/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-ClassPath: target/lib/fernflower.jar,
  .
 Bundle-Name: Enhanced Class Decompiler
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.jface,


### PR DESCRIPTION
- Met à jour les références Java 17 → 21 dans les fichiers *.xml*, *.yml*/*.yaml*, *.properties*, *.sh* et artefacts OSGi/Tycho (MANIFEST.MF, *.target, *.tpd, *.product, *.bnd, feature.xml, category.xml).
- Aucune installation de JDK. SDKMAN est utilisé uniquement pour résoudre les dernières versions 21.
- Remplacements dynamiques des commandes SDKMAN: Temurin=21.0.8-tem; Oracle=21.0.8-oracle.