### PR TITLE
Fix typos

### DIFF
--- a/org.sf.feeling.decompiler.tests/src/org/sf/feeling/decompiler/util/DecompilerOutputUtilTest.java
+++ b/org.sf.feeling.decompiler.tests/src/org/sf/feeling/decompiler/util/DecompilerOutputUtilTest.java
@@ -248,7 +248,7 @@ public class ExampleFour {
         DecompilerOutputUtil util = new DecompilerOutputUtil("""
 package test;
 
-public class ExempleTry {
+public class ExampleTry {
   public static void main(String[] args) {
     try {
       Thread.sleep(100L);// 7
@@ -268,7 +268,7 @@ public class ExempleTry {
 /*    */ package test;
 /*    */
 /*    */
-/*    */ public class ExempleTry {
+/*    */ public class ExampleTry {
 /*    */   public static void main(String[] args) {
 /*    */     try {
 /*  7 */       Thread.sleep(100L);


### PR DESCRIPTION
Automated typo fixes using typos only.
Pass 1: typos safe auto-fixes (write mode)
Pass 2: first-suggestion fixes for remaining ambiguous cases (bash parser)