### PR TITLE
Replace leading tabs in XML and JAVA files

### DIFF
--- a/io.github.nbauma109.decompiler/src/io/github/nbauma109/decompiler/preferences/JavaDecompilerPreferencePage.java
+++ b/io.github.nbauma109.decompiler/src/io/github/nbauma109/decompiler/preferences/JavaDecompilerPreferencePage.java
@@ -172,10 +172,10 @@ public class JavaDecompilerPreferencePage extends FieldEditorPreferencePage impl
     }
 
     private void createExcludePackagesFieldEditor(Group group) {
-    	StringFieldEditor excludePackages = new StringFieldEditor(JavaDecompilerPlugin.EXCLUDE_PACKAGES,
-    			Messages.getString("JavaDecompilerPreferencePage.Label.Attach.ExcludePackages"), //$NON-NLS-1$
-    			group);
-    	addField(excludePackages);
+        StringFieldEditor excludePackages = new StringFieldEditor(JavaDecompilerPlugin.EXCLUDE_PACKAGES,
+                Messages.getString("JavaDecompilerPreferencePage.Label.Attach.ExcludePackages"), //$NON-NLS-1$
+                group);
+        addField(excludePackages);
     }
 
     private void createEncodingFieldEditor(Composite composite) {


### PR DESCRIPTION
Automated indentation normalization:
- XML: leading tabs → two spaces
- JAVA: leading tabs → four spaces