### PR TITLE
Replace leading tabs in XML and JAVA files

### DIFF
--- a/io.github.nbauma109.decompiler.tests/src/io/github/nbauma109/decompiler/editor/BaseDecompilerSourceMapperTest.java
+++ b/io.github.nbauma109.decompiler.tests/src/io/github/nbauma109/decompiler/editor/BaseDecompilerSourceMapperTest.java
@@ -104,27 +104,27 @@ public class BaseDecompilerSourceMapperTest {
 
     @Test
     public void testBuildRealignSuccessReport() throws Exception {
-    	assertTrue(BaseDecompilerSourceMapper.buildRealignSuccessReport().matches("Parsed and realigned by jd-util \\d+\\.\\d+\\.\\d+"));
+        assertTrue(BaseDecompilerSourceMapper.buildRealignSuccessReport().matches("Parsed and realigned by jd-util \\d+\\.\\d+\\.\\d+"));
     }
 
     @Test
     public void testPrintDecompileReport() throws Exception {
-    	StringBuilder source = new StringBuilder("class A {}");
-    	subject.printDecompileReport(source, "path/to/file", Collections.emptyList(), null);
-    	assertEquals("class A {}\n"
-    			+ "\n"
-    			+ "/*\n"
-    			+ "	DECOMPILATION REPORT\n"
-    			+ "\n"
-    			+ "	Decompiled from: path/to/file\n"
-    			+ "	Total time: 0 ms\n"
-    			+ "	\n"
-    			+ "	Decompiled with "
-    			+ subject.getDecompilerName()
-    			+ " version "
-    			+ subject.getDecompilerVersion()
-    			+ ".\n"
-    			+ "*/", source.toString());
+        StringBuilder source = new StringBuilder("class A {}");
+        subject.printDecompileReport(source, "path/to/file", Collections.emptyList(), null);
+        assertEquals("class A {}\n"
+                + "\n"
+                + "/*\n"
+                + "	DECOMPILATION REPORT\n"
+                + "\n"
+                + "	Decompiled from: path/to/file\n"
+                + "	Total time: 0 ms\n"
+                + "	\n"
+                + "	Decompiled with "
+                + subject.getDecompilerName()
+                + " version "
+                + subject.getDecompilerVersion()
+                + ".\n"
+                + "*/", source.toString());
     }
 
     private IType createType(String packageName, String typeName) throws Exception {

--- a/io.github.nbauma109.decompiler/src/io/github/nbauma109/decompiler/editor/BaseDecompilerSourceMapper.java
+++ b/io.github.nbauma109.decompiler/src/io/github/nbauma109/decompiler/editor/BaseDecompilerSourceMapper.java
@@ -499,11 +499,11 @@ public class BaseDecompilerSourceMapper extends DecompilerSourceMapper {
         }
     }
 
-	public String getDecompilerName() {
-		return currentDecompiler.getName();
-	}
+    public String getDecompilerName() {
+        return currentDecompiler.getName();
+    }
 
-	public String getDecompilerVersion() {
-		return currentDecompiler.getDecompilerVersion();
-	}
+    public String getDecompilerVersion() {
+        return currentDecompiler.getDecompilerVersion();
+    }
 }


### PR DESCRIPTION
Automated indentation normalization:
- XML: leading tabs → two spaces
- JAVA: leading tabs → four spaces