### PR TITLE
Fix typos

### DIFF
--- a/io.github.nbauma109.decompiler/src/io/github/nbauma109/decompiler/search/ApplicationLibrarySearchParticipant.java
+++ b/io.github.nbauma109.decompiler/src/io/github/nbauma109/decompiler/search/ApplicationLibrarySearchParticipant.java
@@ -63,8 +63,8 @@ public class ApplicationLibrarySearchParticipant implements IQueryParticipant {
         Set<String> registeredHandles = new HashSet<>();
         if (searchResult != null) {
             for (Object obj : searchResult.getElements()) {
-                if (obj instanceof BytecodeSearchElement bse) {
-                    registeredHandles.add(bse.getEntry().getElementHandle());
+                if (obj instanceof BytecodeSearchElement base) {
+                    registeredHandles.add(base.getEntry().getElementHandle());
                 }
             }
         }


### PR DESCRIPTION
Automated typo fixes using typos only.
Pass 1: typos safe auto-fixes (write mode)
Pass 2: first-suggestion fixes for remaining ambiguous cases (bash parser)