### PR TITLE
Avoid useless selectAndReveal

### DIFF
--- a/io.github.nbauma109.decompiler/src/io/github/nbauma109/decompiler/editor/JavaDecompilerClassFileEditor.java
+++ b/io.github.nbauma109.decompiler/src/io/github/nbauma109/decompiler/editor/JavaDecompilerClassFileEditor.java
@@ -51,6 +51,9 @@ import org.eclipse.jdt.internal.ui.javaeditor.ClassFileEditor;
 import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
 import org.eclipse.jdt.internal.ui.javaeditor.IClassFileEditorInput;
 import org.eclipse.jdt.internal.ui.javaeditor.InternalClassFileEditorInput;
+import org.eclipse.jdt.ui.IPackagesViewPart;
+import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jdt.ui.StandardJavaElementContentProvider;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -58,11 +61,11 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IFindReplaceTarget;
 import org.eclipse.jface.text.source.SourceViewer;
-import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.swt.SWT;
 import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StackLayout;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.events.PaintEvent;
@@ -93,9 +96,6 @@ import org.eclipse.ui.texteditor.ITextEditorActionConstants;
 import org.eclipse.ui.texteditor.ITextEditorActionDefinitionIds;
 import org.eclipse.ui.texteditor.IWorkbenchActionDefinitionIds;
 import org.eclipse.ui.texteditor.IncrementalFindAction;
-import org.eclipse.jdt.ui.IPackagesViewPart;
-import org.eclipse.jdt.ui.JavaUI;
-import org.eclipse.jdt.ui.StandardJavaElementContentProvider;
 
 import io.github.nbauma109.decompiler.JavaDecompilerPlugin;
 import io.github.nbauma109.decompiler.actions.DecompileActionGroup;
@@ -1287,7 +1287,7 @@ public class JavaDecompilerClassFileEditor extends ClassFileEditor {
             return;
         }
         IViewPart view = getSite().getPage().findView(JavaUI.ID_PACKAGES);
-        if (view instanceof IPackagesViewPart packageView && packageView.isLinkingEnabled()) {
+        if (view instanceof IPackagesViewPart packageView && packageView.isLinkingEnabled() && !isPackageExplorerSelection(packageView, javaElement)) {
             ensurePackageExplorerViewShowsMembers(packageView);
             expandPackageExplorerParents(packageView, javaElement);
             packageView.selectAndReveal(javaElement);


### PR DESCRIPTION
Avoid useless selectAndReveal that makes the Package Explorer flickering